### PR TITLE
Fix compile error "‘paramQuantity’ was not declared in this scope".

### DIFF
--- a/src/HolonicSystems-Free.hpp
+++ b/src/HolonicSystems-Free.hpp
@@ -85,7 +85,7 @@ struct HolonicSystemsKnob : RoundSmallBlackKnob {
 	}
 	
 	std::string formatCurrentValue() {
-		int index = int(paramQuantity->getValue());
+		int index = int(getParamQuantity()->getValue());
 		int size =  (int)names.size();
 		if (size>0 && index < size && index >= 0) {
 			return names[index];


### PR DESCRIPTION
Fixes the error "HolonicSystems/src/HolonicSystems-Free.hpp:88:33: error: ‘paramQuantity’ was not declared in this scope; did you mean ‘getParamQuantity’".

May be related to #23.